### PR TITLE
프론트엔드 코드 내에서 https 리다이렉트 작업

### DIFF
--- a/hooks/use-https.ts
+++ b/hooks/use-https.ts
@@ -12,7 +12,7 @@ const useHttps = () => {
                 'https'
             );
         }
-    }, [window.location.origin, window.location.protocol]);
+    }, []);
 };
 
 export default useHttps;

--- a/hooks/use-https.ts
+++ b/hooks/use-https.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+const useHttps = () => {
+    useEffect(() => {
+        const { origin, protocol } = window.location;
+
+        if (origin.startsWith('localhost') || origin.startsWith('127.0.0.1')) {
+            // eslint-disable-next-line no-empty
+        } else if (protocol.startsWith('http')) {
+            window.location.href = window.location.href.replace(
+                'http',
+                'https'
+            );
+        }
+    }, [window.location.origin, window.location.protocol]);
+};
+
+export default useHttps;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,10 +3,12 @@ import Layout from '../components/layout';
 import '../styles/globals.css';
 import usePwaInstall from '../hooks/use-pwa-install';
 import useKakaoApi from '../hooks/use-kakao-api';
+import useHttps from '../hooks/use-https';
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
     usePwaInstall();
     useKakaoApi();
+    useHttps();
 
     return (
         <Layout>


### PR DESCRIPTION
## DONE
* React custom hook을 사용하여 useEffect로 클라이언트 https 리다이렉션 작업
* protocol이 딸려오는 문제 때문에 origin 대신 hostname 사용 [참고 문서 (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Location)

Closes #26.