### PR TITLE
현재 지도 중심 위치와 헤더 행정구역 연동

### DIFF
--- a/components/kakao-map.tsx
+++ b/components/kakao-map.tsx
@@ -1,10 +1,62 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import useKakaoMapInit from '../hooks/use-kakao-map-init';
+import useMapState from '../store/map';
+import { type KakaoMapType, RegionResponse } from '../types/kakao';
+import useMapHeader from '../store/map-header';
+import { KakaoMapSingleton } from '../utils/kakao';
 
 export const kakaoMapDivId = 'kakao-map';
 
+export const extractAddress = (result: RegionResponse) => {
+    return ([1, 2, 3] as Array<1 | 2 | 3>)
+        .map((idx) => {
+            return result[0][`region_${idx}depth_name`];
+        })
+        .filter((e) => e)
+        .reduce((a, b) => `${a} ${b}`);
+};
+
 const KakaoMap = () => {
-    const map = useKakaoMapInit();
+    useKakaoMapInit();
+
+    const { map: mapState } = useMapState();
+    const mapRef = useRef<KakaoMapType>();
+
+    const { changeLocation } = useMapHeader();
+
+    useEffect(() => {
+        if (mapState) {
+            mapRef.current = mapState;
+        }
+    }, [mapState]);
+
+    useEffect(() => {
+        const id = setInterval(() => {
+            const map = mapRef.current;
+
+            if (!map) {
+                return;
+            }
+            const latLng = map.getCenter();
+
+            const geocoder = new KakaoMapSingleton.maps.services.Geocoder();
+
+            geocoder.coord2RegionCode(
+                latLng.getLng(),
+                latLng.getLat(),
+                (result, status) => {
+                    if (!result.length) {
+                        return;
+                    }
+
+                    const address = extractAddress(result);
+                    changeLocation(address);
+                }
+            );
+        }, 1000);
+
+        return () => clearInterval(id);
+    }, [mapRef]);
 
     return (
         <div

--- a/components/kakao-map.tsx
+++ b/components/kakao-map.tsx
@@ -59,14 +59,13 @@ const KakaoMap = () => {
     }, [mapRef]);
 
     return (
-        <div
-            id={kakaoMapDivId}
-            // FIXME: hard-coded width, height size
-            style={{
-                width: '100vw',
-                height: '85vh'
-            }}
-        />
+        <div className="w-screen flex flex-1 my-0">
+            <div
+                id={kakaoMapDivId}
+                // FIXME: hard-coded width, height size
+                className="w-[100%] h-[100%]"
+            />
+        </div>
     );
 };
 

--- a/components/meta-configs.tsx
+++ b/components/meta-configs.tsx
@@ -96,7 +96,7 @@ const MetaConfigs = () => {
             {/* eslint-disable-next-line @next/next/no-sync-scripts */}
             <script
                 type="text/javascript"
-                src={`https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_WEB_API_KEY}`}
+                src={`https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_WEB_API_KEY}&libraries=services`}
             />
         </Head>
     );

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -17,7 +17,7 @@ const Navbar = () => {
 
     const RootNavbar = useCallback(
         ({ children }: { children?: ReactNode }) => (
-            <div className="flex flex-row w-screen bg-fuchsia-500 h-[7.5vh]">
+            <div className="flex flex-row w-screen bg-fuchsia-500 min-h-[7.5vh] flex-shrink">
                 {children}
             </div>
         ),
@@ -50,7 +50,7 @@ const Navbar = () => {
                             }`}
                         >
                             {icon && (
-                                <div className="mx-auto mt-auto mb-0 flex flex-1 flex-grow">
+                                <div className="mx-auto mt-0 mb-0 flex flex-1 flex-grow">
                                     {createElement(MuiIcons[icon], {
                                         className:
                                             'flex-1 my-auto mx-auto text-3xl md:text-4xl lg:text-5xl'
@@ -58,7 +58,7 @@ const Navbar = () => {
                                 </div>
                             )}
                             <div
-                                className={`mx-auto mb-auto text-base md:text-lg lg:text-xl ${
+                                className={`mx-auto mb-auto text-base md:text-lg lg:text-xl flex-1 flex-grow ${
                                     icon ? 'mt-0' : 'mt-auto'
                                 }`}
                             >

--- a/hooks/use-kakao-map-init.ts
+++ b/hooks/use-kakao-map-init.ts
@@ -1,14 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { KakaoMapSingleton } from '../utils/kakao';
-import { type KakaoMapType } from '../types/kakao';
 import useCurrentLatLng from '../store/current-latlng';
+import useMapState from '../store/map';
 
-export type UseKakaoMapInitResult = {
-    map: KakaoMapType;
-};
+const useKakaoMapInit = () => {
+    const { map, setMap } = useMapState();
 
-const useKakaoMapInit = (): UseKakaoMapInitResult => {
-    const [map, setMap] = useState<KakaoMapType | null>(null);
     const { lat, lng, zoomLevel } = useCurrentLatLng();
 
     useEffect(() => {
@@ -16,7 +13,7 @@ const useKakaoMapInit = (): UseKakaoMapInitResult => {
         const container = document.getElementById('kakao-map');
 
         if (!container || !lat || !lng) {
-            return;
+            return () => {};
         }
 
         const options = {
@@ -25,11 +22,11 @@ const useKakaoMapInit = (): UseKakaoMapInitResult => {
         };
 
         setMap(new KakaoMapSingleton.maps.Map(container, options));
-    }, [lat, lng, zoomLevel]);
 
-    return {
-        map
-    };
+        return () => {
+            setMap(null);
+        };
+    }, [lat, lng, zoomLevel]);
 };
 
 export default useKakaoMapInit;

--- a/store/map.ts
+++ b/store/map.ts
@@ -1,0 +1,17 @@
+import create from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { type KakaoMapType } from '../types/kakao';
+
+export interface MapState {
+    map: KakaoMapType | null;
+    setMap: (map_: KakaoMapType | null) => void;
+}
+
+const useMapState = create<MapState>(
+    devtools((set, get) => ({
+        map: null,
+        setMap: (map: KakaoMapType | null) => set({ map })
+    }))
+);
+
+export default useMapState;

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,3 +1,12 @@
+body {
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+    scrollbar-width: none; /* Firefox */
+}
+
+body::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+}
+
 .center-children {
     display: flex;
 }
@@ -17,4 +26,7 @@
 .MuiDialog-container.MuiDialog-scrollPaper {
     height: 100vh;
     width: 100vw;
+    
+    height: calc(100 * var(--vh));
+    width: calc(100 * var(--vw));
 }

--- a/styles/common.css
+++ b/styles/common.css
@@ -26,7 +26,4 @@ body::-webkit-scrollbar {
 .MuiDialog-container.MuiDialog-scrollPaper {
     height: 100vh;
     width: 100vw;
-    
-    height: calc(100 * var(--vh));
-    width: calc(100 * var(--vw));
 }

--- a/types/kakao.d.ts
+++ b/types/kakao.d.ts
@@ -1,5 +1,32 @@
-export type KakaoLatLngType = unknown;
-export type KakaoMapType = unknown;
+export type KakaoLatLngType = {
+    getLat: () => number;
+    getLng: () => number;
+};
+export type KakaoMapType = {
+    getCenter(): KakaoLatLngType;
+};
+
+export type Status = 'OK' | 'ZERO_RESULT' | 'ERROR';
+
+export type RegionResponse = Array<{
+    region_type: string;
+    address_name: string;
+    region_1depth_name: string;
+    region_2depth_name: string;
+    region_3depth_name: string;
+    region_4depth_name: string;
+    code: string;
+    x: number;
+    y: number;
+}>;
+
+export type KakaoGeocoderType = {
+    coord2RegionCode: (
+        lng: number,
+        lat: number,
+        callback: (result: RegionResponse, status: Status) => void
+    ) => void;
+};
 
 export type KakaoSingletonType = {
     init: (key: string) => void;
@@ -13,6 +40,11 @@ export type KakaoMapSingletonType = {
         };
         Map: {
             new (container: HTMLElement, options: object): KakaoMapType;
+        };
+        services: {
+            Geocoder: {
+                new (): KakaoGeocoderType;
+            };
         };
     };
 };


### PR DESCRIPTION
## DONE
* 카카오 지도 API 서비스 라이브러리 불러오기
* 카카오 지도 API 타입 정의 추가
* 현재 지도 위치와 헤더 행정구역 연동
* 스크롤바 숨기기
* 지도 반응형 디자인으로 변경