### PR TITLE
놀러가기 페이지 추가

### DIFF
--- a/components/friend-item.tsx
+++ b/components/friend-item.tsx
@@ -1,6 +1,15 @@
+import { useRouter } from 'next/router';
 import { Friend } from '../types/jmtapi';
 
 const FriendItem = ({ friend }: { friend: Friend }) => {
+    const router = useRouter();
+    const onClickHangOut = () => {
+        router.push({
+            pathname: '/maps/friends/[uid]',
+            query: { uid: friend.toUser.id }
+        });
+    };
+
     return (
         <div className="flex my-2 w-full items-center border-2 border-gray-800 text-gray-800 bg-white">
             <div className="w-20">
@@ -19,6 +28,7 @@ const FriendItem = ({ friend }: { friend: Friend }) => {
                     <button
                         type="button"
                         className="p-2 border-2 text-gray-800 border-gray-800 bg-green-100"
+                        onClick={onClickHangOut}
                     >
                         놀러가기
                     </button>

--- a/pages/api/routes.ts
+++ b/pages/api/routes.ts
@@ -23,11 +23,6 @@ export default function getRoutes(
             icon: 'Map'
         },
         {
-            uri: '/maps/friends',
-            name: '친구 지도',
-            icon: 'Map'
-        },
-        {
             uri: '/maps',
             name: '지도 목록',
             icon: 'ZoomInMap'

--- a/pages/friends/management.tsx
+++ b/pages/friends/management.tsx
@@ -43,8 +43,6 @@ const Management: NextPage = () => {
             page: page - 1,
             size
         });
-        console.log(params);
-        console.log('page', page);
 
         const res = await fetch(url + params, {
             method: 'GET',
@@ -59,7 +57,6 @@ const Management: NextPage = () => {
         }
 
         const result = (await res.json()) as Page<Friend>;
-        console.log('yo', result);
         setFriends(result);
     };
 

--- a/pages/friends/requests.tsx
+++ b/pages/friends/requests.tsx
@@ -30,8 +30,6 @@ const FriendRequests: NextPage = () => {
         const { backend } = await fetchRemotes();
         const url = `${backend}/api/v1/friend-requests?`;
 
-        console.log('fetching friend requests');
-        console.log(page);
         const params = qs.stringify({
             'to-user-id': user?.id,
             status: 'PENDING',
@@ -52,7 +50,6 @@ const FriendRequests: NextPage = () => {
         }
 
         const result = (await res.json()) as Page<FriendRequest>;
-        console.log(result);
         setFriendRequests(result);
     };
 

--- a/pages/maps/friends/[uid].tsx
+++ b/pages/maps/friends/[uid].tsx
@@ -1,21 +1,70 @@
 import type { NextPage } from 'next';
-import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import qs from 'qs';
+
 import KakaoMap from '../../../components/kakao-map';
 import useMapHeader from '../../../store/map-header';
 import useCurrentLatLng from '../../../store/current-latlng';
 import { jungLatLng } from '../../../utils/sample-latlngs';
+import { UserResponse } from '../../../types/jmtapi';
+import useAuth from '../../../store/auth';
+import { fetchRemotes } from '../../../utils/remotes';
+import useSnackbarHandler from '../../../store/snackbar';
+
+interface ExpectedQuery {
+    uid: string;
+}
 
 const Friends: NextPage = () => {
+    const router = useRouter();
+    const { setMessage: setSnackbarMessage } = useSnackbarHandler();
+    const { user } = useAuth();
+    const [friendUser, setFriendUser] = useState<UserResponse | null>(null);
+
     const { changeTitle, changeLocation } = useMapHeader();
     const { changeLatLng } = useCurrentLatLng();
 
-    useEffect(() => {
-        changeTitle('오션의');
+    const fetchFriendUser = async (friendUserId: string) => {
+        // friendUser;
+        const { backend } = await fetchRemotes();
+        const url = `${backend}/api/v1/users/${friendUserId}`;
+
+        const res = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Content-type': 'application/json'
+            }
+        });
+
+        if (!res.ok) {
+            console.error(res.statusText);
+            return;
+        }
+
+        const result = (await res.json()) as UserResponse;
+        setFriendUser(result);
+
+        changeTitle(`${result.nickname as string}의`);
         changeLocation('서울특별시 중구');
+    };
 
+    useEffect(() => {
         const { lat, lng } = jungLatLng;
-
         changeLatLng(lat, lng);
+
+        if (!user) {
+            setSnackbarMessage(
+                'error',
+                '비로그인 사용자는 해당 페이지에 접근이 불가능합니다.'
+            );
+            router.push('/');
+        }
+
+        (async () => {
+            const friendUserId = router.query.uid as string;
+            await fetchFriendUser(friendUserId);
+        })();
     }, []);
 
     return <KakaoMap />;

--- a/pages/maps/friends/[uid].tsx
+++ b/pages/maps/friends/[uid].tsx
@@ -1,9 +1,9 @@
 import type { NextPage } from 'next';
 import { useEffect } from 'react';
-import KakaoMap from '../../components/kakao-map';
-import useMapHeader from '../../store/map-header';
-import useCurrentLatLng from '../../store/current-latlng';
-import { jungLatLng } from '../../utils/sample-latlngs';
+import KakaoMap from '../../../components/kakao-map';
+import useMapHeader from '../../../store/map-header';
+import useCurrentLatLng from '../../../store/current-latlng';
+import { jungLatLng } from '../../../utils/sample-latlngs';
 
 const Friends: NextPage = () => {
     const { changeTitle, changeLocation } = useMapHeader();


### PR DESCRIPTION
## ABOUT

놀러가기 페이지를 추가합니다.

친구 관리에서 놀러가기 버튼을 누르게 되면,
![친구 관리 - 놀러가기 버튼](https://user-images.githubusercontent.com/42485462/179259554-aa2bd956-f1c7-4ae2-a38e-baba3a211ef7.png)

친구의 이름이 표시된 지도 화면으로 이동하게 됩니다.
![놀러가기 버튼 눌렀을 시 화면](https://user-images.githubusercontent.com/42485462/179260231-7c57a85a-f5bf-47f5-bb66-b2515fea17cb.png)

## DONE

- 놀러가기 버튼 누르면 페이지 이동
- 기존의 친구 관리 페이지를 **bottom 네비게이션 바에서 제거** (`api.routes` 수정)
- 기존의 친구 관리 페이지 구성을 `/friends/index`가 아닌 `/friends/[uid]`로 변경
- 놀러가기 페이지에서 사용자 프로필 API를 이용해 타이틀 변경
